### PR TITLE
Escape >, <, and & in PR title

### DIFF
--- a/pullbot.rb
+++ b/pullbot.rb
@@ -58,7 +58,8 @@ helpers do
                          "text" => {
                               "type" => "mrkdwn",
                               "text" => "*[<#{repo_meta['html_url']}|#{repo_meta['full_name']}>]*"\
-                                        " <#{pr['html_url']}|_#{pr['title']}_ *##{pr['number']}*>"
+                                        " <#{pr['html_url']}|_#{pr['title'].gsub(/&/,'&amp;').gsub(/>/,'&gt;').gsub(/</,'&lt;')}"\
+                                        "_ *##{pr['number']}*>"
                          }
                     },
                     {

--- a/pullbot.rb
+++ b/pullbot.rb
@@ -58,8 +58,8 @@ helpers do
                          "text" => {
                               "type" => "mrkdwn",
                               "text" => "*[<#{repo_meta['html_url']}|#{repo_meta['full_name']}>]*"\
-                                        " <#{pr['html_url']}|_#{pr['title'].gsub(/&/,'&amp;').gsub(/>/,'&gt;').gsub(/</,'&lt;')}"\
-                                        "_ *##{pr['number']}*>"
+                                        " <#{pr['html_url']}|_#{pr['title'].gsub(/&/,'&amp;').gsub(/>/,'&gt;').gsub(/</,'&lt;')}_ "\
+                                        "*##{pr['number']}*>"
                          }
                     },
                     {


### PR DESCRIPTION
This is escaping necessity is explained here:
https://api.slack.com/reference/surfaces/formatting#escaping

I tested it under the 'mrkdwn' section here:
https://app.slack.com/block-kit-builder/T025FUEFN

Closes https://github.com/iFixit/PullBot/issues/10